### PR TITLE
Use forked verison of zetasql (myhau/zetasql 0.5.5-fork.1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,4 +97,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240314234333-6e1732d8331c // indirect
 )
 
-replace github.com/goccy/go-zetasqlite v0.19.2 => github.com/myhau/go-zetasqlite v0.19.2-fork.1
+replace github.com/goccy/go-zetasqlite => github.com/myhau/go-zetasqlite v0.19.2-fork.1
+
+replace github.com/goccy/go-zetasql => github.com/myhau/go-zetasql v0.5.5-fork.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
-github.com/goccy/go-zetasql v0.5.5 h1:3JpXt3p2533rnZMu09upCcI7YJ2KfjKgdo2Lu0xo+fU=
-github.com/goccy/go-zetasql v0.5.5/go.mod h1:xvvooX2RG404vnbdFZuAM8bTFksYwVUlqeIUrUNuo40=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -167,6 +165,8 @@ github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 h1:AMFGa4R4MiIpsp
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8DFdX7uMikMLXX4oubIzJF4kv/wI=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
+github.com/myhau/go-zetasql v0.5.5-fork.1 h1:LA6b4mNi2VnH52AaZ/EIKrpmJnxYRF/Tczcl8z9StSE=
+github.com/myhau/go-zetasql v0.5.5-fork.1/go.mod h1:xvvooX2RG404vnbdFZuAM8bTFksYwVUlqeIUrUNuo40=
 github.com/myhau/go-zetasqlite v0.19.2-fork.1 h1:u7qOHLdSrQxx06pNYgaOtKVWTfyn2I9OvDf+90IK0s4=
 github.com/myhau/go-zetasqlite v0.19.2-fork.1/go.mod h1:ThavIQcmI6a/sVTpvJtj+idUui32gwbnXe1jeb7pISY=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=


### PR DESCRIPTION
`0.5.5-fork.1` improves error strings. See the related PR https://github.com/myhau/go-zetasql/pull/1.