### PR TITLE
add dataset existence validation for uploadContentRequest

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -403,10 +403,13 @@ func (h *uploadContentHandler) Handle(ctx context.Context, r *uploadContentReque
 	load := r.job.Content().Configuration.Load
 	tableRef := load.DestinationTable
 	dataset := r.project.Dataset(tableRef.DatasetId)
+	if dataset == nil {
+		return fmt.Errorf("dataset `%s` is not found", tableRef.DatasetId)
+	}
 	table := dataset.Table(tableRef.TableId)
 	if table == nil {
 		if load.CreateDisposition == "CREATE_NEVER" {
-			return fmt.Errorf("`%s` is not found", tableRef.TableId)
+			return fmt.Errorf("table `%s` is not found", tableRef.TableId)
 		}
 		if _, err := (&tablesInsertHandler{}).Handle(ctx, &tablesInsertRequest{
 			server:  r.server,


### PR DESCRIPTION

# Problem

When creating load job that loads JSON from GCS emulator (https://github.com/fsouza/fake-gcs-server), BigQuery emulator fails with:

```
com.google.api.client.googleapis.json.GoogleJsonResponseException: 500 Internal Server Error POST http://localhost:33144/bigquery/v2/projects/test-project/jobs?prettyPrint=false {   "code" : 500,   "errors" : [ {     "location" : "",     "message" : "runtime error: invalid memory address or nil pointer dereference",     "reason" : "internalError",     "debugInfo" : ""   } ],   "message" : "runtime error: invalid memory address or nil pointer dereference" }
```

# Solution

Check if dataset exists.


# Possibly related

- https://github.com/goccy/bigquery-emulator/pull/189
- https://github.com/goccy/bigquery-emulator/issues/136